### PR TITLE
Updated travis to run test's on Go 1.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ sudo: required
 language: go
 
 go:
-  - "1.11.x"
   - "1.12.x"
+  - "1.13.x"
   - master
 
 script:


### PR DESCRIPTION
- Added 1.13 into travis build
- Removed 1.11 as [it is no longer supported ](https://golang.org/doc/devel/release.html#policy)